### PR TITLE
Indent element children after an opening tag

### DIFF
--- a/languages/xml/indents.scm
+++ b/languages/xml/indents.scm
@@ -1,2 +1,6 @@
 (STag ">" @end) @indent
 (EmptyElemTag "/>" @end) @indent
+
+(element
+  (STag) @start
+  (ETag)? @end) @indent


### PR DESCRIPTION
Fixes #30.

This adds an element-level indent rule to `indents.scm`, following the pattern used by [Zed's built-in HTML extension](https://github.com/zed-industries/zed/blob/main/extensions/html/languages/html/indents.scm):

```scheme
(element
  (STag) @start
  (ETag)? @end) @indent
```

Lines between an element's opening and closing tag are indented one level deeper, and the line containing the closing tag is outdented back to the level of the opening tag:

```xml
<Record element="data">
  <Value select="1"/>
</Record>
```

The two existing rules (multi-line attribute indentation inside a tag) are kept unchanged.

### Verification

Checked the query against the grammar revision pinned in `extension.toml` (`tree-sitter-grammars/tree-sitter-xml@863dbc3`) with the tree-sitter CLI. For the reproduction case from the issue, the new pattern captures `@start` at the STag and `@end` at the ETag, so the rows in between get one extra indent level and the closing tag row does not. The query also runs cleanly over `test/example.xml`.

### Note on unclosed tags

While an element has no matching closing tag yet, this strict XML grammar wraps the region in an `ERROR` node without an `element`, so tree-sitter-based auto-indent cannot kick in until the document parses again. That is unchanged from before; the optional `(ETag)?` capture mirrors how the HTML extension handles it (the HTML grammar is just more lenient during error recovery).